### PR TITLE
Adds support for encoding null values

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ json.decode('[1,2,3,{"x":10}]') -- Returns { 1, 2, 3, { x = 10 } }
   or invalid numbers (NaN, -inf, inf) will raise an error
 * `null` values contained within an array or object are converted to `nil` and
   are therefore lost upon decoding
+* Alternatively `null` values may be encoded using `json.null` instead of `nil`
 * *Pretty* encoding is not supported, `json.encode()` only encodes to a compact
   format
 

--- a/json.lua
+++ b/json.lua
@@ -10,6 +10,15 @@
 local json = { _version = "0.1.0" }
 
 -------------------------------------------------------------------------------
+-- Null encoding support
+-------------------------------------------------------------------------------
+local _null_type = "null"
+local _null_mt = {
+    __index={ __type = _null_type }
+}
+json.null = setmetatable({}, _null_mt)
+
+-------------------------------------------------------------------------------
 -- Encode
 -------------------------------------------------------------------------------
 
@@ -42,6 +51,10 @@ end
 
 
 local function encode_table(val, stack)
+  if val.__type == _null_type then
+      return encode_nil(val)
+  end
+
   local res = {}
   stack = stack or {}
 
@@ -375,6 +388,5 @@ function json.decode(str)
   end
   return ( parse(str, next_char(str, 1, space_chars, true)) )
 end
-
 
 return json

--- a/test/test.lua
+++ b/test/test.lua
@@ -235,4 +235,11 @@ test("encode escape", function()
   end
 end)
 
+test("encode null", function()
+    assert( json.encode{foo=json.null} == [[{"foo":null}]],
+            "json.null was not preserved" )
+
+    assert( json.encode({foo=nil}) == "[]",
+            "nil was not lost" )
+end)
 


### PR DESCRIPTION
I've modified json.lua for a project where I must preserve nulls when encoding.
I've made a PR here in case this change is something others might find useful.
Feel free to close if this is somehow against the minimal spirit of this project :)