### PR TITLE
fix array detection when using overloaded indexing

### DIFF
--- a/json.lua
+++ b/json.lua
@@ -65,7 +65,7 @@ local function encode_table(val, stack)
 
   stack[val] = true
 
-  if val[1] ~= nil or next(val) == nil then
+  if rawget(val[1]) ~= nil or next(val) == nil then
     -- Treat as array -- check keys are valid and it is not sparse
     local n = 0
     for k in pairs(val) do


### PR DESCRIPTION
I was writing my own little math (linear algebra) library, and I was running into issues with serializing my objects, because I had added an indexing "overload" (using metamethod __index) to my Vector and Matrix objects. So you could use them like normal arrays, something like this:

```lua
local v = Vector({1, 2, 3, 4})
local vectorSize = v.size
local firstValue = v[1]    --should be 1
local secondValue = v[2]    --should be 2
local rawFirstValue = rawget(firstvalue, 1)    --nil, because it isn't actually an array, it's a vector object
```

Of course when serializing the library was confused about wether or not this was an array or a table, this can be fixed easily by not indexing naively, but using rawget-