### PR TITLE
Fix serializing of tables with overloaded indexing / using __index metamethod

### DIFF
--- a/json.lua
+++ b/json.lua
@@ -65,7 +65,7 @@ local function encode_table(val, stack)
 
   stack[val] = true
 
-  if val[1] ~= nil or next(val) == nil then
+  if rawget(val, 1) ~= nil or next(val) == nil then
     -- Treat as array -- check keys are valid and it is not sparse
     local n = 0
     for k in pairs(val) do


### PR DESCRIPTION
I was writing my own linear algebra math, library, in particular Matrix and Vector classes and I was running into issues serializing them because I had overloaded the indexing of Matrix and Vector classes, to make them more intuitive

```lua
local v = Vector({1, 2, 3, 4})   --create vector object
local vectorSIze = v.size        --get the vector size (just showcasing normal property access)
local firstElement = v[1]        --get the first element of the array. the vector object itself doesn't have a value with key 1, but the object still allows accessing the underlying values directly
local firstRawElement = getraw(v, 1) --is nil
```

Of course this has confused the serializer, because it thinks it's an array and not a table, event if it's not.
The fix for this is simply to use rawget instead of [1] when testing for an array.