### PR TITLE
Fix escape sequence parser for decoding strings

### DIFF
--- a/json.lua
+++ b/json.lua
@@ -219,15 +219,13 @@ local function parse_string(str, i)
   local s = {}
   local j = i + 1
   while j <= #str do
-    local x = str:byte(j)
 
-    local k = j
-    while not (x < 32 or x == 92 or x == 34) do
-        j = j + 1
-	x = str:byte(j)
+    local k, l = str:find("^[^%c\\\"]+", j)
+    if k then
+      table.insert(s, str:sub(k, l))
+      j = l + 1
     end
-
-    table.insert(s, str:sub(k, j - 1))
+    local x = str:byte(j)
 
     if x < 32 then
       decode_error(str, j, "control character in string")

--- a/json.lua
+++ b/json.lua
@@ -232,6 +232,9 @@ local function parse_string(str, i)
           decode_error(str, j, "invalid unicode escape in string")
         end
         if hex:find("^[dD][89aAbB]") then
+          if not str:sub(j + 8, j + 12):find("%x%x%x%x") then
+            decode_error(str, j + 6, "invalid unicode continue sequence in string")
+          end
           s = s .. parse_unicode_escape(str:sub(j, j + 12))
           j = j + 12
         else


### PR DESCRIPTION
Improved logic to parse escape sequences when decoding strings. The former gsub logic is replaced by a clean token parser.

This fixes the problem that the parser tries to decode any ``\u`` sequence (also invalid unicode escape sequences) when a valid escape sequence is found somewhere else in the string.

MNWE:

```lua
json = require("json")
json.decode("{\"fail\":\"\\\\url{http://www.example.com/} vs. \\u0023\"}")
```