### PR TITLE
Register in the World of Warcraft library "LibStub" if detected

### DIFF
--- a/json.lua
+++ b/json.lua
@@ -22,7 +22,44 @@
 -- SOFTWARE.
 --
 
-local json = { _version = "0.1.2" }
+local json
+
+do
+  -- Semantic version. all lowercase.
+  -- Suffix can be alpha1, alpha2, beta1, beta2, rc1, rc2, etc.
+  -- NOTE: Two version numbers need to be modified.
+  -- 1. _version
+  -- 2. _minor
+
+  -- version to store the official version of json.lua
+  local _version = "0.1.2"
+
+  -- When major is changed, it should be changed to json2
+  local _major = "json"
+
+  -- Update this whenever a new version, for LibStub version registration.
+  local _minor = 1
+
+  -- Register in the World of Warcraft library "LibStub" if detected.
+  if LibStub then
+    local lib, minor = LibStub:GetLibrary(_major, true)
+    if lib and minor and minor >= _minor then -- No need to update.
+      return lib
+    else -- Update or first time register
+      json = LibStub:NewLibrary(_major, _minor)
+      -- NOTE: It is important that new version has implemented
+      -- all exported APIs and tables in the old version,
+      -- so the old library is fully garbage collected,
+      -- and we 100% ensure the backward compatibility.
+    end
+  else -- "LibStub" is not detected.
+    json = {}
+  end
+
+  json._version = _version
+  json._major = _major
+  json._minor = _minor
+end
 
 -------------------------------------------------------------------------------
 -- Encode

--- a/lib.xml
+++ b/lib.xml
@@ -1,0 +1,4 @@
+<Ui xmlns="http://www.blizzard.com/wow/ui/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.blizzard.com/wow/ui/
+..\FrameXML\UI.xsd">
+	<Script file="json.lua" />
+</Ui>


### PR DESCRIPTION
json.lua does not currently work within a World of Warcraft addon because it needs to be registered as a LibStub library. This solves that issue by only registering it if LibStub exists when initially running (so it will continue to work correctly outside of a World of Warcraft addon)

Since json.lua is the only maintained json lua library I know of, it would be great to add World of Warcraft addon support so that there is a good way to do json within addons :)