### PR TITLE
Sort keys when encoding tables

### DIFF
--- a/json.lua
+++ b/json.lua
@@ -24,6 +24,21 @@
 
 local json = { _version = "0.1.2" }
 
+-- taken from https://www.lua.org/pil/19.3.html
+function pairsByKeys (t, f)
+  local a = {}
+  for n in pairs(t) do table.insert(a, n) end
+  table.sort(a, f)
+  local i = 0      -- iterator variable
+  local iter = function ()   -- iterator function
+    i = i + 1
+    if a[i] == nil then return nil
+    else return a[i], t[a[i]]
+    end
+  end
+  return iter
+end
+
 -------------------------------------------------------------------------------
 -- Encode
 -------------------------------------------------------------------------------
@@ -86,7 +101,7 @@ local function encode_table(val, stack)
 
   else
     -- Treat as an object
-    for k, v in pairs(val) do
+    for k, v in pairsByKeys(val) do
       if type(k) ~= "string" then
         error("invalid table: mixed or invalid key types")
       end

--- a/test/test.lua
+++ b/test/test.lua
@@ -93,7 +93,9 @@ end)
 
 test("objects", function()
   local t = { x = 10, y = 20, z = 30 }
-  assert( equal( t, json.decode( json.encode(t) ) ) )
+  local encoded = json.encode(t)
+  assert( equal( '{"x":10,"y":20,"z":30}', encoded) )
+  assert( equal( t, json.decode( encoded ) ) )
 end)
 
 


### PR DESCRIPTION
This makes sure encoding a table always leads to the same JSON by sorting the keys.